### PR TITLE
Fix Tool Proficiencies on Character Sheet

### DIFF
--- a/scripts/patch/config.mjs
+++ b/scripts/patch/config.mjs
@@ -463,6 +463,19 @@ export function patchConfig(config, strict = true) {
 		valahorn: "Compendium.sw5e.musicalinstruments.Item.sNnvwOZrUp5xJuHe",
 		xantha: "Compendium.sw5e.musicalinstruments.Item.WVSGXxzBoTUoPvi9",
 	};
+	for (const id in config.toolIds) {
+		let toolAbility = "int";
+		const uuid = config.toolIds[id];
+
+		if (uuid.includes(".gamingsets.") || uuid.includes(".musicalinstruments.")) {
+			toolAbility = "cha";
+		}
+
+		config.tools[id] = {
+			ability: toolAbility,
+			id: uuid
+		}
+	}
 	// Ability Consumption
 	config.abilityConsumptionTypes.powerDice = "SW5E.PowerDice";
 	config.abilityConsumptionTypes.shieldDice = "SW5E.ShieldDice";


### PR DESCRIPTION
Now the tool proficiencies do appear on the character sheet 📝.

<img width="600" height="666" alt="imagen" src="https://github.com/user-attachments/assets/99d2d066-4509-4795-94c6-ddf283b12f6e" />
