### PR TITLE
Fix incompatibility/conflict with DnD 5.2.X

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,12 @@ If you wish to manually install the system, you must clone or extract it into th
 
 ## Changelog
 
-### [1.2.8] - 2025-11-26
+### [1.2.8] - 2025-12-03
 
 ### Fixed
 
 - Weapon Templates on Attacks.
+- DnD5e 5.2 Conflict/Incompatibility.
 
 ### [1.2.7] - 2025-11-21
 

--- a/scripts/patch/addHooks.mjs
+++ b/scripts/patch/addHooks.mjs
@@ -53,9 +53,9 @@ export function addHooks() {
 	//-------------------//
 
 	// ActorSheet5e Hooks
-	addHook('dnd5e.applications.actor.ActorSheet5e.prototype._onDropSpell', 'ActorSheet5e._onDropSpell');
-	addHook('dnd5e.applications.actor.ActorSheet5e.prototype._prepareSpellbook', 'ActorSheet5e._prepareSpellbook');
-	addHookAsync('dnd5e.applications.actor.ActorSheet5e.prototype.getData', 'ActorSheet5eCharacter.getData');
+	// addHook('dnd5e.applications.actor.ActorSheet5e.prototype._onDropSpell', 'ActorSheet5e._onDropSpell');
+	// addHook('dnd5e.applications.actor.ActorSheet5e.prototype._prepareSpellbook', 'ActorSheet5e._prepareSpellbook');
+	// addHookAsync('dnd5e.applications.actor.ActorSheet5e.prototype.getData', 'ActorSheet5eCharacter.getData');
 	// ItemSheet5e Hooks
 	// ?
 	// ActivityUsageDialog Hooks

--- a/scripts/patch/maneuver.mjs
+++ b/scripts/patch/maneuver.mjs
@@ -137,6 +137,7 @@ function makeProgOption(config) {
 }
 
 function showPowercastingStats() {
+	/*
 	const { simplifyBonus } = dnd5e.utils;
 	Hooks.on('sw5e.ActorSheet5eCharacter.getData', function (_this, context, config, ...args) {
 		const msak = simplifyBonus(_this.actor.system.bonuses.msak.attack, context.rollData);
@@ -157,6 +158,7 @@ function showPowercastingStats() {
 			});
 		}
 	});
+	*/
 }
 
 function patchItemSheet() {
@@ -210,6 +212,7 @@ function patchPowerAbilityScore() {
 }
 
 function patchPowerbooks() {
+	/*
 	Hooks.on('sw5e.ActorSheet5e._prepareSpellbook', function (_this, powerbook, config, ...args) {
 		const [context, spells] = args;
 
@@ -262,6 +265,7 @@ function patchPowerbooks() {
 		// Sort the powerbook by section level
 		config.result = powerbook.sort((a, b) => a.order - b.order);
 	});
+	*/
 }
 
 function recoverSuperiorityDice() {

--- a/scripts/patch/powercasting.mjs
+++ b/scripts/patch/powercasting.mjs
@@ -180,6 +180,7 @@ function makeProgOption(config) {
 }
 
 function showPowercastingStats() {
+	/*
 	const { simplifyBonus } = dnd5e.utils;
 	Hooks.on('sw5e.ActorSheet5eCharacter.getData', function (_this, context, config, ...args) {
 		const msak = simplifyBonus(_this.actor.system.bonuses.msak.attack, context.rollData);
@@ -200,6 +201,7 @@ function showPowercastingStats() {
 			});
 		}
 	});
+	*/
 }
 
 function patchItemSheet() {
@@ -280,6 +282,7 @@ function patchPowerAbilityScore() {
 }
 
 function patchPowerbooks() {
+	/*
 	Hooks.on('sw5e.ActorSheet5e._prepareSpellbook', function (_this, powerbook, config, ...args) {
 		const [context, spells] = args;
 
@@ -341,6 +344,7 @@ function patchPowerbooks() {
 			if (_this.document.type !== "npc") prep.mode = "powerCasting";
 		}
 	});
+	*/
 }
 
 function patchAbilityUseDialog() {


### PR DESCRIPTION
The problem was ultimately the use of "ActorSheet5e" (which I assume is what the ActorSheetMixin warning was referring to) within the module's code, and since apparently ActorSheet5e since DnD 5.0 no longer worked at all or did anything, the mere fact of deleting (or commenting) the lines of code where it was being used was more than enough for everything to work again 📝.

<img width="445" height="125" alt="imagen" src="https://github.com/user-attachments/assets/c0234762-45e0-49a5-a306-aa47598962d7" />
