### PR TITLE
Fix Powercasting Cards on Sheets

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,12 @@ If you wish to manually install the system, you must clone or extract it into th
 
 ## Changelog
 
-### [1.2.8] - 2025-12-03
+### [1.2.8] - 2025-12-14
 
 ### Fixed
 
 - Weapon Templates on Attacks.
+- Powercasting Cards on Sheets.
 - DnD5e 5.2 Conflict/Incompatibility.
 
 ### [1.2.7] - 2025-11-21

--- a/README.md
+++ b/README.md
@@ -15,11 +15,12 @@ If you wish to manually install the system, you must clone or extract it into th
 
 ## Changelog
 
-### [1.2.8] - 2025-11-26
+### [1.2.8] - 2025-12-03
 
 ### Fixed
 
 - Weapon Templates on Attacks.
+- DnD5e 5.2 Conflict/Incompatibility.
 
 ### [1.2.7] - 2025-11-21
 

--- a/scripts/patch/addHooks.mjs
+++ b/scripts/patch/addHooks.mjs
@@ -53,9 +53,9 @@ export function addHooks() {
 	//-------------------//
 
 	// ActorSheet5e Hooks
-	addHook('dnd5e.applications.actor.ActorSheet5e.prototype._onDropSpell', 'ActorSheet5e._onDropSpell');
-	addHook('dnd5e.applications.actor.ActorSheet5e.prototype._prepareSpellbook', 'ActorSheet5e._prepareSpellbook');
-	addHookAsync('dnd5e.applications.actor.ActorSheet5e.prototype.getData', 'ActorSheet5eCharacter.getData');
+	// addHook('dnd5e.applications.actor.ActorSheet5e.prototype._onDropSpell', 'ActorSheet5e._onDropSpell');
+	// addHook('dnd5e.applications.actor.ActorSheet5e.prototype._prepareSpellbook', 'ActorSheet5e._prepareSpellbook');
+	// addHookAsync('dnd5e.applications.actor.ActorSheet5e.prototype.getData', 'ActorSheet5eCharacter.getData');
 	// ItemSheet5e Hooks
 	// ?
 	// ActivityUsageDialog Hooks

--- a/scripts/patch/maneuver.mjs
+++ b/scripts/patch/maneuver.mjs
@@ -137,6 +137,7 @@ function makeProgOption(config) {
 }
 
 function showPowercastingStats() {
+	/*
 	const { simplifyBonus } = dnd5e.utils;
 	Hooks.on('sw5e.ActorSheet5eCharacter.getData', function (_this, context, config, ...args) {
 		const msak = simplifyBonus(_this.actor.system.bonuses.msak.attack, context.rollData);
@@ -157,6 +158,7 @@ function showPowercastingStats() {
 			});
 		}
 	});
+	*/
 }
 
 function patchItemSheet() {
@@ -210,6 +212,7 @@ function patchPowerAbilityScore() {
 }
 
 function patchPowerbooks() {
+	/*
 	Hooks.on('sw5e.ActorSheet5e._prepareSpellbook', function (_this, powerbook, config, ...args) {
 		const [context, spells] = args;
 
@@ -262,6 +265,7 @@ function patchPowerbooks() {
 		// Sort the powerbook by section level
 		config.result = powerbook.sort((a, b) => a.order - b.order);
 	});
+	*/
 }
 
 function recoverSuperiorityDice() {

--- a/scripts/patch/powercasting.mjs
+++ b/scripts/patch/powercasting.mjs
@@ -180,6 +180,7 @@ function makeProgOption(config) {
 }
 
 function showPowercastingStats() {
+	/*
 	const { simplifyBonus } = dnd5e.utils;
 	Hooks.on('sw5e.ActorSheet5eCharacter.getData', function (_this, context, config, ...args) {
 		const msak = simplifyBonus(_this.actor.system.bonuses.msak.attack, context.rollData);
@@ -200,6 +201,7 @@ function showPowercastingStats() {
 			});
 		}
 	});
+	*/
 }
 
 function patchItemSheet() {
@@ -280,6 +282,7 @@ function patchPowerAbilityScore() {
 }
 
 function patchPowerbooks() {
+	/*
 	Hooks.on('sw5e.ActorSheet5e._prepareSpellbook', function (_this, powerbook, config, ...args) {
 		const [context, spells] = args;
 
@@ -341,6 +344,7 @@ function patchPowerbooks() {
 			if (_this.document.type !== "npc") prep.mode = "powerCasting";
 		}
 	});
+	*/
 }
 
 function patchAbilityUseDialog() {


### PR DESCRIPTION
Originally, the powercasting cards on the character sheets were not displayed correctly. Only the spellcasting cards that the DnD system added by default based on the actor's class would appear. Now those cards no longer appear, and only the powercasting ones are displayed depending on whether the actor has at least one corresponding class, power, or maneuver.

https://github.com/user-attachments/assets/cb26b1bc-309c-4726-8709-0421238d746c

