### PR TITLE
Update to dnd5e 5.x release and Foundry 13

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,68 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+npm run build:db          # compile packs/_source/ JSON → packs/ (Foundry LevelDB)
+npm run build:json        # extract packs/ back to packs/_source/ JSON
+npm run build:clean       # normalize/clean pack source data
+npm run build:db -- classes                  # single pack
+npm run build:json -- classes Barbarian      # single entry
+```
+
+**`npm run build:db` requires Foundry VTT to be fully stopped** — Foundry holds a LevelDB lock on `packs/` that blocks the build.
+
+After any `packs/_source/` change: run `build:db`, then restart Foundry (not just browser reload).
+
+There are no tests. There is no frontend bundler — Foundry loads JS/CSS/templates directly from source files at runtime. Code and template changes take effect after a browser reload; pack changes require a rebuild and Foundry restart.
+
+## Architecture
+
+`sw5e-module` is a Foundry VTT module that layers SW5E (Star Wars 5e) content and mechanics onto the `dnd5e` system. It does not fork dnd5e — it patches it at runtime using `lib-wrapper`.
+
+**Targets:** Foundry VTT 13.351, dnd5e 5.2.5, lib-wrapper (required)
+
+**Module ID:** `sw5e-module` — the Foundry data symlink directory must be named `sw5e-module` to match. (The ID was changed from `sw5e` upstream; mismatches cause "Invalid module detected" errors.)
+
+**Entry point:** `module.json` → `scripts/module.mjs`
+- `init` hook: registers settings, lib-wrapper hooks, preloads templates, applies patches
+- `ready` hook: patches pack behavior, finalizes proficiency, runs migrations
+
+### Patch Layer (`scripts/patch/`)
+
+All runtime dnd5e integration lives here. Key files:
+
+| File | Purpose |
+|------|---------|
+| `config.mjs` | Adds SW5E entries to `CONFIG.DND5E` (damage types, abilities, armor classes, tools, etc.) |
+| `dataModels.mjs` | Extends dnd5e data model schemas (powercasting fields, superiority, proficiency changes); registers `ItemSheetSW5E` |
+| `powercasting.mjs` | Force/tech powercasting point computation; hooks into actor prep and sheet rendering |
+| `starship-prepare.mjs` | Derives starship runtime data (hull/shields, movement, crew) from legacy JSON flags |
+| `starship-sheet.mjs` | Injects SW5E and Starship Features tabs into the dnd5e VehicleActorSheet via `renderActorSheetV2` hook |
+| `maneuver.mjs` | Maneuver item type behavior |
+| `addHooks.mjs` | Central hook/wrapper registration |
+
+### Custom Document Types
+
+Only one custom item type is registered: `sw5e-module.maneuver` (declared in `module.json` `documentTypes` and registered in `dataModels.mjs`). All other item types (modifications, deployments, starship sizes, etc.) use generic dnd5e types (`loot`, `feat`, etc.) to stay compatible with upstream.
+
+Starship actors use the stock `vehicle` type, not a custom type. The module identifies them via `actor.flags.sw5e.legacyStarshipActor.type === "starship"`.
+
+### Compendium Workflow
+
+`packs/_source/` is the source of truth — one JSON file per document, organized by pack name. `packs/` contains generated LevelDB databases and is never edited by hand.
+
+The build pipeline (`utils/packs.mjs`) normalizes legacy SW5E data shapes into current dnd5e-compatible forms before writing to the database.
+
+### Localization
+
+All i18n strings live in `languages/en.json`. The module uses `localizeOrFallback(key, fallback)` (defined in `starship-sheet.mjs`) throughout the starship UI to gracefully handle missing keys.
+
+## Key Conventions
+
+- `packs/_source/` JSON is edited; `packs/` is generated. The git repo tracks source, not built output.
+- The `scripts/dnd5e-source-normalization.mjs` and `scripts/starship-data.mjs` files handle legacy starship data — the ships in Drake's Shipyard store their derived values in `flags.sw5e` rather than in the dnd5e schema.
+- dnd5e system source files are at `~/Library/Application Support/FoundryVTT/Data/systems/dnd5e/`. Foundry core is at `/Applications/Foundry Virtual Tabletop.app/Contents/Resources/app/`.
+- The `module-support.mjs` helpers (`getModuleId()`, `getModuleType()`, `getLegacyModuleType()`) abstract over both the `sw5e-module` (current) and `sw5e` (legacy) module IDs.

--- a/languages/en.json
+++ b/languages/en.json
@@ -307,6 +307,7 @@
 			"Passenger": "Passenger"
 		}
 	},
+	"SW5E.Features": "Star Wars 5th Edition Features",
 	"SW5E.FlagsManeuverCritThreshold": "Maneuver Critical Threshold",
 	"SW5E.FlagsManeuverCritThresholdHint": "Reduce the roll required for a critical hit with maneuvers by this amount.",
 	"SW5E.FlagsForcePowerDiscount": "Force Power Cost Discount",

--- a/languages/en.json
+++ b/languages/en.json
@@ -291,8 +291,34 @@
 			"Label": "Deployment Feature",
 			"LabelPl": "Deployment Features",
 			"Venture": "Venture"
+		},
+		"Starship": {
+			"Label": "Starship Feature",
+			"LabelPl": "Starship Features",
+			"Role": "Role",
+			"RoleSpecialization": "Role Specialization",
+			"RoleMastery": "Role Mastery"
+		},
+		"StarshipAction": {
+			"Label": "Starship Action",
+			"LabelPl": "Starship Actions",
+			"Pilot": "Pilot",
+			"Crew": "Crew",
+			"Passenger": "Passenger"
 		}
 	},
+	"SW5E.FlagsManeuverCritThreshold": "Maneuver Critical Threshold",
+	"SW5E.FlagsManeuverCritThresholdHint": "Reduce the roll required for a critical hit with maneuvers by this amount.",
+	"SW5E.FlagsForcePowerDiscount": "Force Power Cost Discount",
+	"SW5E.FlagsForcePowerDiscountHint": "Reduce the force point cost of force powers by this amount (minimum 1).",
+	"SW5E.FlagsTechPowerDiscount": "Tech Power Cost Discount",
+	"SW5E.FlagsTechPowerDiscountHint": "Reduce the tech point cost of tech powers by this amount (minimum 1).",
+	"SW5E.FlagsSupremeAptitude": "Supreme Aptitude",
+	"SW5E.FlagsSupremeAptitudeHint": "Add your proficiency bonus to the damage rolls of tech powers.",
+	"SW5E.FlagsSupremeDurability": "Supreme Durability",
+	"SW5E.FlagsSupremeDurabilityHint": "Add your Constitution modifier to your maximum hit points for each level.",
+	"SW5E.FlagsEncumbranceMultiplier": "Encumbrance Multiplier",
+	"SW5E.FlagsEncumbranceMultiplierHint": "Multiply your carrying capacity by this value.",
 	"SW5E.FreeLearn": "Free Learn",
 	"DND5E.ITEM.Property.Magical": "Enhanced",
 	"SW5E.Item": {

--- a/packs/_source/drakes-shipyard/gand-starfighter.json
+++ b/packs/_source/drakes-shipyard/gand-starfighter.json
@@ -3352,12 +3352,12 @@
       "sort": 0,
       "flags": {
         "core": {
-          "sourceId": "Compendium.sw5e.starshipmodifications.4rKESBEskTCQuqqP"
+          "sourceId": "Compendium.sw5e.starshipmodifications.pa1DzHAExLc3Wp4j"
         }
       },
       "system": {
         "description": {
-          "value": "<p>You install a slave circuit in your ship to improve automation. You reduce the minimum crew requirement by half.</p>",
+          "value": "<p><span style=\"font-family:'Open Sans', sans-serif\">The Fire-Linked Mounting is a modification to a Hardpoint that allows a primary weapon with no constitution requirement to synchronize it's fire with another identical primary weapon having no constitution requirement.</span></p><p><span style=\"font-family:'Open Sans', sans-serif\">When you Fire a primary weapon equipped to this hardpoint, you can use an object interaction to link an eligible weapon and a bonus action to Fire the linked weapon in the same firing arc if it has not yet been Fired this round. You don't add the ship's ability modifier to the damage roll of the bonus attack, unless that modifier is negative. A weapon that has been Fired using your bonus action in this way cannot be Fired again this round.</span></p>",
           "chat": ""
         },
         "source": {},
@@ -3466,7 +3466,7 @@
         "createdTime": null,
         "modifiedTime": 1685838233307,
         "lastModifiedBy": null,
-        "compendiumSource": "Compendium.sw5e.starshipmodifications.4rKESBEskTCQuqqP",
+        "compendiumSource": "Compendium.sw5e.starshipmodifications.pa1DzHAExLc3Wp4j",
         "duplicateSource": null
       },
       "_key": "!actors.items!DiyflQC8xEhqvrzp.DlkD8Z4tO6ZqqS0G"
@@ -3481,12 +3481,12 @@
       "sort": 0,
       "flags": {
         "core": {
-          "sourceId": "Compendium.sw5e.starshipmodifications.4rKESBEskTCQuqqP"
+          "sourceId": "Compendium.sw5e.starshipmodifications.kOMRqFfo6NbckGTx"
         }
       },
       "system": {
         "description": {
-          "value": "<p>You install a slave circuit in your ship to improve automation. You reduce the minimum crew requirement by half.</p>",
+          "value": "<p><span style=\"font-family:'Open Sans', sans-serif\">You can gain the benefits of your Fire-Linked Mounting even if one or both weapons have a constitution requirement.</span><br class=\"Apple-interchange-newline\" /><br class=\"Apple-interchange-newline\" /><br class=\"Apple-interchange-newline\" /></p>",
           "chat": ""
         },
         "source": {},
@@ -3595,7 +3595,7 @@
         "createdTime": null,
         "modifiedTime": 1685838233307,
         "lastModifiedBy": null,
-        "compendiumSource": "Compendium.sw5e.starshipmodifications.4rKESBEskTCQuqqP",
+        "compendiumSource": "Compendium.sw5e.starshipmodifications.kOMRqFfo6NbckGTx",
         "duplicateSource": null
       },
       "_key": "!actors.items!DiyflQC8xEhqvrzp.PbkggwbucoihseAM"

--- a/scripts/patch/config.mjs
+++ b/scripts/patch/config.mjs
@@ -512,7 +512,7 @@ export function patchConfig(config, strict = true) {
 		config.tools[id] = {
 			ability: toolAbility,
 			type: toolType,
-			id: uuid
+			id: normalizeCompendiumUuid(uuid)
 		}
 	}
 	// Ability Consumption

--- a/scripts/patch/starship-sheet.mjs
+++ b/scripts/patch/starship-sheet.mjs
@@ -231,7 +231,8 @@ function formatPowerSummary(legacySystem) {
 
 function getSizeLabel(actor, legacySystem) {
 	const sizeKey = actor.system?.traits?.size ?? legacySystem.traits?.size ?? "";
-	return CONFIG.DND5E.actorSizes?.[sizeKey] ?? sizeKey ?? "-";
+	const entry = CONFIG.DND5E.actorSizes?.[sizeKey];
+	return (typeof entry === "string" ? entry : entry?.label) ?? sizeKey ?? "-";
 }
 
 function getDeploymentCounts(legacySystem) {

--- a/scripts/patch/starship-sheet.mjs
+++ b/scripts/patch/starship-sheet.mjs
@@ -48,7 +48,7 @@ function getPrimaryTabPanelParent(root) {
 }
 
 function getTabButton(root, tabId) {
-	return getPrimaryTabNav(root)?.querySelector(`.item[data-tab="${tabId}"]`) ?? null;
+	return getPrimaryTabNav(root)?.querySelector(`[data-tab="${tabId}"]`) ?? null;
 }
 
 function getStarshipActiveTab(app) {
@@ -64,7 +64,7 @@ function setStarshipActiveTab(app, tabId = null) {
 function activatePrimaryTab(root, tabId) {
 	const nav = getPrimaryTabNav(root);
 	if ( nav ) {
-		nav.querySelectorAll(".item[data-tab]").forEach(item => {
+		nav.querySelectorAll("[data-tab]").forEach(item => {
 			item.classList.toggle("active", item.dataset.tab === tabId);
 		});
 	}
@@ -612,19 +612,17 @@ async function renderStarshipLayer(app, html, data) {
 		})
 	]);
 
-	const tabButton = document.createElement("button");
-	tabButton.type = "button";
-	tabButton.className = "item sw5e-starship-tab-button";
+	const tabButton = document.createElement("a");
+	tabButton.className = "sw5e-starship-tab-button";
 	tabButton.dataset.group = "primary";
 	tabButton.dataset.tab = STARSHIP_TAB_ID;
-	tabButton.textContent = "SW5E";
+	tabButton.innerHTML = `<span>SW5E</span>`;
 
-	const featuresTabButton = document.createElement("button");
-	featuresTabButton.type = "button";
-	featuresTabButton.className = "item sw5e-starship-tab-button sw5e-starship-features-tab-button";
+	const featuresTabButton = document.createElement("a");
+	featuresTabButton.className = "sw5e-starship-tab-button sw5e-starship-features-tab-button";
 	featuresTabButton.dataset.group = "primary";
 	featuresTabButton.dataset.tab = STARSHIP_FEATURES_TAB_ID;
-	featuresTabButton.textContent = localizeOrFallback("SW5E.Feature.Starship.Label", "Features");
+	featuresTabButton.innerHTML = `<span>${localizeOrFallback("SW5E.Feature.Starship.LabelPl", "Starship Features")}</span>`;
 
 	const wrapper = document.createElement("section");
 	wrapper.className = "tab sw5e-starship-tab";
@@ -697,7 +695,7 @@ async function renderStarshipLayer(app, html, data) {
 	featuresWrapper.addEventListener("click", handleTabClick);
 
 	if ( integrated ) {
-		nav.querySelectorAll(".item[data-tab]").forEach(item => {
+		nav.querySelectorAll("[data-tab]").forEach(item => {
 			if ( item === tabButton || item === featuresTabButton ) return;
 			if ( CUSTOM_STARSHIP_TAB_IDS.has(item.dataset.tab) ) return;
 			item.addEventListener("click", () => {

--- a/scripts/patch/starship-sheet.mjs
+++ b/scripts/patch/starship-sheet.mjs
@@ -72,7 +72,14 @@ function activatePrimaryTab(root, tabId) {
 	root.querySelectorAll(".tab[data-group='primary']").forEach(panel => {
 		const isActive = panel.dataset.tab === tabId;
 		panel.classList.toggle("active", isActive);
-		panel.hidden = !isActive;
+		// Only manage `hidden` on our own custom tabs.
+		// Stock dnd5e panels use CSS classes for visibility; setting `hidden` on them
+		// prevents dnd5e from showing them again when the user clicks back to cargo/description.
+		if ( panel.classList.contains("sw5e-starship-tab") ) {
+			panel.hidden = !isActive;
+		} else {
+			panel.hidden = false;
+		}
 	});
 }
 

--- a/styles/module.css
+++ b/styles/module.css
@@ -434,13 +434,12 @@
   }
 }
 
+.dnd5e2.sheet.actor.sw5e-starship-sheet .sheet-tabs {
+  font-size: var(--font-size-11);
+}
+
 .dnd5e2.sheet.actor.sw5e-starship-sheet .sw5e-starship-tab-button {
-  appearance: none;
-  border: 0;
-  background: transparent;
-  color: inherit;
-  letter-spacing: 0.08em;
-  cursor: pointer;
+  white-space: nowrap;
 }
 
 .dnd5e2.sheet.actor.sw5e-starship-sheet .sw5e-starship-tab-host {


### PR DESCRIPTION
Full transparency: I'm using Claude Code to update this sw5e-module to the latest D&D 5.x release compatibility for Foundry 13.

I'm going to test it to my best ability and move this PR out of draft mode when ready.

I realize this is most likely a backwards-incompatible change with Foundry 11/12, so we may want to instead merge this change into a `foundry13` branch, to preserve the old version and not surprise new installers with a breaking change.

## Changes beyond upstream v.next

- **Fix undefined source label in starship and maneuver sheets** — `prepareDerivedData` now guards `this.source.label` in a `finally` block so the source-book span in the window header renders as empty instead of "undefined" when `SourceField.prepareData` hasn't run yet.

- **Fix NaN/NaN encumbrance display on starship actor sheets** — dnd5e's `calculateThreshold` checks `type === "vehicle"` to use cargo capacity as the encumbrance ceiling; `sw5e.starship` fell through to the str-based path but `VehicleData` has no abilities, producing NaN. Now clamps using `attributes.capacity.cargo.value` directly.

- **Add missing i18n strings for starship feature types and character flags** — Adds `SW5E.Feature.Starship.*` and `SW5E.Feature.StarshipAction.*` so starship actor features show "Pilot Action" / "Crew Action" instead of raw keys; adds `SW5E.Features` section label and `SW5E.Flags*` name/hint strings for the PC special traits panel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Starship armor class configuration
  ~~* Introduced new abilities: Honor and Sanity~~
  * Added Starship and Starship Action feature categories
  * Added configurable flags for maneuver critical thresholds, power discounts, supreme abilities, and encumbrance multipliers

* **Updates**
  * Refactored condition type system for improved consistency
  * Reorganized spell preparation mode structure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->