### PR TITLE
Fix starship sheet navigation, i18n, and vehicle type

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ All runtime dnd5e integration lives here. Key files:
 | `dataModels.mjs` | Extends dnd5e data model schemas (powercasting fields, superiority, proficiency changes); registers `ItemSheetSW5E` |
 | `powercasting.mjs` | Force/tech powercasting point computation; hooks into actor prep and sheet rendering |
 | `starship-prepare.mjs` | Derives starship runtime data (hull/shields, movement, crew) from legacy JSON flags |
-| `starship-sheet.mjs` | Injects SW5E and Starship Features tabs into the dnd5e VehicleActorSheet via `renderActorSheetV2` hook |
+| `starship-sheet.mjs` | Injects SW5E and Starship Features tabs into the dnd5e VehicleActorSheet via `renderActorSheetV2` hook — see [`docs/actor-sheet-tabs.md`](docs/actor-sheet-tabs.md) for tab system details |
 | `maneuver.mjs` | Maneuver item type behavior |
 | `addHooks.mjs` | Central hook/wrapper registration |
 

--- a/docs/actor-sheet-tabs.md
+++ b/docs/actor-sheet-tabs.md
@@ -54,6 +54,29 @@ Key option: `{ force: true }` bypasses the early-return guard that does nothing 
 
 The default `tabGroups.primary = "inventory"`.
 
+### Item categorization — what goes where
+
+`VehicleActorSheet._assignItemCategories(item)` determines which part of the stock sheet each item renders in:
+
+```javascript
+if ( item.type === "container" )       → inventory tab
+if ( item.type === "facility" )        → facilities
+if ( item.system.isMountable )         → stations (crew stations list)
+if ( "inventorySection" in model )     → inventory tab   ← weapon, equipment, loot, consumable, tool
+else                                   → stations (features section)  ← feat, sw5e-module.maneuver
+```
+
+**Practical rule for SW5E starship items:**
+
+| Item type | Goes to |
+|-----------|---------|
+| `feat` (starship actions, features, deployments, ventures) | `stations` sidebar — always visible, no tab switch needed |
+| `weapon` (starship weapons) | `inventory` tab |
+| `equipment` (reactors, hyperdrives, power couplings) | `inventory` tab |
+| `loot` / physical items (modifications) | `inventory` tab |
+
+This matters for "Find in Sheet" navigation: `focusSheetItem` determines the correct tab from the DOM (`.tab[data-group='primary']`). For feat-type items it finds them in `stations` (panel = null → no tab switch, just scroll). For physical items it finds them in the `inventory` panel → switches to the cargo tab then scrolls.
+
 ## SW5E Custom Tab Injection
 
 `renderStarshipLayer` (in `starship-sheet.mjs`) hooks into `renderActorSheetV2` and injects two custom tabs into the primary nav:
@@ -135,3 +158,4 @@ Do not put `data-action="tab"` on non-nav elements (e.g., action buttons) even i
 | Features tab blanks out after "Find in Sheet" | `data-application-part` fallback resolves to `"stations"` (not a nav tab); `changeTab` throws; catch falls to `activatePrimaryTab` which deactivates all panels | Only resolve tab ID from `.tab[data-group='primary']`, not `data-application-part` |
 | Custom tab button stays highlighted after navigating away | Custom button `.active` not removed; `app.changeTab` handles this automatically when `force: true` is used | Ensure stock-tab path calls `app.changeTab` with `force: true` |
 | Stock tab button click dispatched as a synthetic event | `changeTab` exits early (same reasons above); using `dispatchEvent` bypasses the `force` option | Use `app.changeTab` directly instead of synthesizing click events |
+| `scrollIntoView` on a tab panel item does nothing | Panel was `display:none` when `scrollIntoView` was called; browser has not yet painted the `display:block` change | Wrap `scrollIntoView` in `window.requestAnimationFrame(...)` after `activateSheetTab` |

--- a/docs/actor-sheet-tabs.md
+++ b/docs/actor-sheet-tabs.md
@@ -1,0 +1,137 @@
+# Actor Sheet Tab System
+
+This document explains how Foundry v13 / dnd5e 5.x tab management works, how the SW5E module injects its own tabs into the vehicle sheet, and the rules to follow when writing code that navigates between tabs.
+
+## How Foundry v13 ApplicationV2 Manages Tabs
+
+In Foundry v13, `ApplicationV2`-based sheets manage tab state with two mechanisms:
+
+### 1. CSS visibility — the primary mechanism
+
+```css
+.tab[data-tab]:not(.active) { display: none; }
+```
+
+Tab panels are shown and hidden by toggling the `.active` class. The `hidden` HTML attribute is **not** the primary visibility control for stock panels — CSS is.
+
+### 2. `app.tabGroups` — the state record
+
+```javascript
+app.tabGroups = { primary: "inventory" }
+```
+
+`tabGroups` tracks which tab is active per group. It is updated by `app.changeTab()`. **It is not updated automatically when you manipulate classes directly.**
+
+### 3. `app.changeTab(tab, group, options)`
+
+The authoritative API for switching tabs. It:
+
+- Looks up the matching nav element (`.tabs [data-group="${group}"][data-tab="${tab}"]`) — **throws if not found**
+- Toggles `.active` on all nav buttons in the group
+- Toggles `.active` on all `.tab[data-group="${group}"]` panels
+- Updates `tabGroups[group] = tab`
+
+Key option: `{ force: true }` bypasses the early-return guard that does nothing when `tabGroups[group]` already equals `tab`. **Always pass `force: true` when activating a stock tab from custom tab code**, because our custom tab activation does not update `tabGroups`.
+
+## dnd5e 5.x VehicleActorSheet Structure
+
+```
+.window-content
+├── [data-application-part="sidebarCollapser"]
+├── [data-application-part="sidebar"]          — always visible, not a tab
+├── [data-application-part="stations"]         — always visible sidebar section (NOT a nav tab)
+├── [data-application-part="tabs"]             — renders the primary tab nav
+└── #tabs.tab-body
+    ├── [data-application-part="inventory"]    tab: "inventory"  (labeled "Cargo")
+    ├── [data-application-part="crew"]         tab: "crew"
+    ├── [data-application-part="effects"]      tab: "effects"
+    └── [data-application-part="description"]  tab: "description"
+```
+
+**There is no `"cargo"` tab.** The tab labeled "Cargo" in the UI has `data-tab="inventory"`.
+
+**`stations` is not a nav tab.** It is a sidebar part rendered outside the `#tabs` container. Items that appear in `stations` do not require a tab switch to view — that section is always visible.
+
+The default `tabGroups.primary = "inventory"`.
+
+## SW5E Custom Tab Injection
+
+`renderStarshipLayer` (in `starship-sheet.mjs`) hooks into `renderActorSheetV2` and injects two custom tabs into the primary nav:
+
+| Tab ID | Button class | Panel class |
+|--------|-------------|-------------|
+| `sw5e-starship` | `sw5e-starship-tab-button` | `tab sw5e-starship-tab` |
+| `sw5e-starship-features` | `sw5e-starship-tab-button sw5e-starship-features-tab-button` | `tab sw5e-starship-tab sw5e-starship-features-tab` |
+
+Both panels are appended to the primary tab panel container (`panelParent`) with `data-group="primary"` and `data-tab`, so Foundry's `changeTab` naturally includes them when iterating panels.
+
+### Custom tab visibility
+
+Custom tab panels use **both** `.active` class (via Foundry CSS) **and** the `hidden` attribute. Both are set when activating or deactivating custom tabs. This is because CSS alone is sufficient, but `hidden` provides belt-and-suspenders and is reliable when panels are detached and re-attached.
+
+### `_sw5eStarshipActiveTab`
+
+The active custom tab is tracked on `app._sw5eStarshipActiveTab`:
+
+- `"sw5e-starship"` — SW5E tab is active
+- `"sw5e-starship-features"` — Features tab is active
+- `null` — a stock tab is active (custom tabs hidden)
+- `undefined` — initial state before first render (treated as SW5E tab)
+
+This is checked during `renderActorSheetV2` re-renders to restore the correct panel state.
+
+## Rules for Tab Navigation Code
+
+### Activating a custom tab (`activateSheetTab` in `starship-sheet.mjs`)
+
+Call `activatePrimaryTab(root, tabId)` which:
+1. Toggles `.active` on nav buttons
+2. Toggles `.active` on panels
+3. Sets `hidden = true` on inactive custom panels, `hidden = false` on stock panels (stock panels are controlled by CSS, but `hidden` is cleared in case it was set by a previous interaction)
+
+Do **not** call `app.changeTab` for custom tabs — the custom tab IDs are not registered in dnd5e's tab system and will throw.
+
+### Activating a stock tab (`activateSheetTab` in `starship-sheet.mjs`)
+
+1. Set `_sw5eStarshipActiveTab = null`
+2. Remove `.active` and set `hidden = true` on all custom panels
+3. Call `app.changeTab(tabId, "primary", { force: true, updatePosition: false })`
+
+**Why `force: true`:** Custom tab activation does not update `app.tabGroups`, so `tabGroups.primary` may already equal the target tab. Without `force`, `changeTab` exits early and never restores `.active` on the target panel. The panel stays `display: none` via CSS and the sheet appears blank.
+
+Wrap in try/catch: if `tabId` is not a registered nav tab (e.g., `"stations"`), `changeTab` will throw. The catch block should fall back to `activatePrimaryTab(root, tabId)` or do nothing.
+
+### "Find in Sheet" navigation
+
+When navigating from a custom tab to show an item in the stock sheet:
+
+1. Search for `[data-item-id="${itemId}"]` elements **outside** `.sw5e-starship-tab` panels
+2. Check if the found element is inside a `.tab[data-group='primary']` panel
+3. If yes → call `activateSheetTab` with `panel.dataset.tab`
+4. If no (e.g., item is in the `stations` sidebar section) → **skip tab navigation** and just scroll to the item; the `stations` section is always visible
+
+Do **not** use `data-application-part` as a fallback tab ID. `data-application-part` values like `"stations"` are part IDs, not nav tab IDs, and passing them to `changeTab` throws.
+
+```javascript
+// Correct pattern:
+const panel = target.closest(".tab[data-group='primary']");
+if ( panel?.dataset.tab ) activateSheetTab(root, app, panel.dataset.tab);
+target.scrollIntoView({ behavior: "smooth", block: "center" });
+```
+
+### Click events in custom panels
+
+Custom panel click handlers (delegated on the panel element) should use `event.preventDefault()` for action buttons. Do **not** add `event.stopPropagation()` unless you have a specific reason — stopping propagation can interfere with navigation actions that depend on the event reaching ancestor handlers.
+
+### Tab buttons in custom panels
+
+Do not put `data-action="tab"` on non-nav elements (e.g., action buttons) even if they have a `data-tab` attribute. Foundry's `_onClickTab` handler reads `data-action="tab"` to detect tab switches. A button with only `data-tab` (no `data-action`) will not trigger Foundry's tab system.
+
+## Common Pitfalls
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Sheet goes blank after tab switch | `changeTab` called without `force: true`; `tabGroups` already matches target tab, so it exits early and never restores `.active` on the target panel | Pass `{ force: true }` |
+| Features tab blanks out after "Find in Sheet" | `data-application-part` fallback resolves to `"stations"` (not a nav tab); `changeTab` throws; catch falls to `activatePrimaryTab` which deactivates all panels | Only resolve tab ID from `.tab[data-group='primary']`, not `data-application-part` |
+| Custom tab button stays highlighted after navigating away | Custom button `.active` not removed; `app.changeTab` handles this automatically when `force: true` is used | Ensure stock-tab path calls `app.changeTab` with `force: true` |
+| Stock tab button click dispatched as a synthetic event | `changeTab` exits early (same reasons above); using `dispatchEvent` bypasses the `force` option | Use `app.changeTab` directly instead of synthesizing click events |

--- a/languages/en.json
+++ b/languages/en.json
@@ -177,6 +177,9 @@
 	"DND5E.DamageThunder": "Sonic",
 
 	"SW5E.EquipmentFocusGenerator": "Focus Generator",
+	"SW5E.EquipmentHyperdrive": "Hyperdrive",
+	"SW5E.EquipmentPowerCoupling": "Power Coupling",
+	"SW5E.EquipmentReactor": "Reactor",
 	"SW5E.EquipmentStarshipArmor": "Starship Armor",
 	"SW5E.EquipmentWristpad": "Wristpad",
 	"SW5E.CreatureDroid": "Droid",

--- a/packs/_source/starships/gargantuan-starship.json
+++ b/packs/_source/starships/gargantuan-starship.json
@@ -174,7 +174,10 @@
     "fuelCap": 1800,
     "foodCap": 576000000,
     "size": "grg",
-    "startingEquipment": []
+    "startingEquipment": [],
+    "details": {
+      "type": "space"
+    }
   },
   "ownership": {
     "default": 0

--- a/packs/_source/starships/huge-starship.json
+++ b/packs/_source/starships/huge-starship.json
@@ -174,7 +174,10 @@
     "fuelCap": 600,
     "foodCap": 9600000,
     "size": "huge",
-    "startingEquipment": []
+    "startingEquipment": [],
+    "details": {
+      "type": "space"
+    }
   },
   "ownership": {
     "default": 0

--- a/packs/_source/starships/large-starship.json
+++ b/packs/_source/starships/large-starship.json
@@ -174,7 +174,10 @@
     "fuelCap": 300,
     "foodCap": 240000,
     "size": "lg",
-    "startingEquipment": []
+    "startingEquipment": [],
+    "details": {
+      "type": "space"
+    }
   },
   "ownership": {
     "default": 0

--- a/packs/_source/starships/medium-starship.json
+++ b/packs/_source/starships/medium-starship.json
@@ -162,7 +162,10 @@
     "fuelCap": 30,
     "foodCap": 120,
     "size": "med",
-    "startingEquipment": []
+    "startingEquipment": [],
+    "details": {
+      "type": "space"
+    }
   },
   "ownership": {
     "default": 0

--- a/packs/_source/starships/small-starship.json
+++ b/packs/_source/starships/small-starship.json
@@ -174,7 +174,10 @@
     "fuelCap": 10,
     "foodCap": 10,
     "size": "sm",
-    "startingEquipment": []
+    "startingEquipment": [],
+    "details": {
+      "type": "space"
+    }
   },
   "ownership": {
     "default": 0

--- a/packs/_source/starships/tiny-starship.json
+++ b/packs/_source/starships/tiny-starship.json
@@ -174,7 +174,10 @@
     "fuelCap": 5,
     "foodCap": 0,
     "size": "tiny",
-    "startingEquipment": []
+    "startingEquipment": [],
+    "details": {
+      "type": "space"
+    }
   },
   "ownership": {
     "default": 0

--- a/scripts/patch/starship-prepare.mjs
+++ b/scripts/patch/starship-prepare.mjs
@@ -31,6 +31,7 @@ export function patchStarshipPrepare() {
 						actorSource.system.abilities = mergedAbilities;
 					}
 				}
+
 			}
 
 			const result = wrapped(...args);

--- a/scripts/patch/starship-sheet.mjs
+++ b/scripts/patch/starship-sheet.mjs
@@ -91,14 +91,16 @@ function activateSheetTab(root, app, tabId) {
 	}
 
 	setStarshipActiveTab(app, null);
-	const button = getTabButton(root, tabId);
-	if ( button ) {
-		button.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
-		if ( !button.classList.contains("active") ) activatePrimaryTab(root, tabId);
-		return;
+	root.querySelectorAll(".sw5e-starship-tab").forEach(panel => { panel.classList.remove("active"); panel.hidden = true; });
+	if ( typeof app?.changeTab === "function" ) {
+		try {
+			app.changeTab(tabId, "primary", { force: true, updatePosition: false });
+		} catch(e) {
+			activatePrimaryTab(root, tabId);
+		}
+	} else {
+		activatePrimaryTab(root, tabId);
 	}
-
-	activatePrimaryTab(root, tabId);
 }
 
 function ensureStarshipTabTargets(root) {
@@ -485,11 +487,13 @@ async function renderStarshipSidebarSummary(root, actor) {
 }
 
 function focusSheetItem(root, app, itemId, tabId = STOCK_CARGO_TAB_ID) {
-	activateSheetTab(root, app, tabId);
 	window.setTimeout(() => {
 		const candidates = root.querySelectorAll(`[data-item-id="${itemId}"]`);
 		const target = Array.from(candidates).find(node => !node.closest(".sw5e-starship-tab"));
 		if ( !target ) return;
+		// Only switch tabs if the item is inside a named tab panel; non-tab sections (e.g. stations sidebar) are always visible.
+		const panel = target.closest(".tab[data-group='primary']");
+		if ( panel?.dataset.tab ) activateSheetTab(root, app, panel.dataset.tab);
 		target.scrollIntoView({ behavior: "smooth", block: "center" });
 		target.classList.add("sw5e-starship-item-pulse");
 		window.setTimeout(() => target.classList.remove("sw5e-starship-item-pulse"), 1800);

--- a/scripts/patch/starship-sheet.mjs
+++ b/scripts/patch/starship-sheet.mjs
@@ -610,14 +610,14 @@ async function renderStarshipLayer(app, html, data) {
 			subtitle: localizeOrFallback("TYPES.Actor.vehicle", "Vehicle Actor"),
 			headerBadges: makeHeaderBadges(actor),
 			overviewCards: makeOverviewCards(actor),
-			groups: workspaceGroups.map(group => ({ ...group, supportsSheetNavigation: integrated, showManageButton: integrated })),
+			groups: workspaceGroups.map(group => ({ ...group, supportsSheetNavigation: integrated })),
 			legacyNotes: getLegacyNotes(actor),
 			skills
 		}),
 		foundry.applications.handlebars.renderTemplate(getModulePath("templates/starship-features-layer.hbs"), {
 			title: localizeOrFallback("SW5E.Feature.Starship.Label", "Starship Features"),
 			subtitle: "Manage configuration items and remove or replace them through the stock vehicle sheet.",
-			groups: featureGroups.map(group => ({ ...group, supportsSheetNavigation: integrated, showManageButton: integrated }))
+			groups: featureGroups.map(group => ({ ...group, supportsSheetNavigation: integrated }))
 		})
 	]);
 

--- a/scripts/patch/starship-sheet.mjs
+++ b/scripts/patch/starship-sheet.mjs
@@ -346,7 +346,7 @@ function getItemMeta(item, actor = null) {
 		return item.system?.type?.subtype ?? "Modification";
 	}
 
-	if ( item.system?.type?.subtype ) return item.system.type.subtype;
+	if ( item.system?.type?.subtype ) return game.i18n.localize(item.system.type.subtype);
 	const pack = getCompendiumPack(item);
 	if ( actor && item.type === "weapon" ) {
 		const routingMultiplier = getDerivedStarshipRuntime(actor).routing?.weaponsMultiplier ?? 1;

--- a/scripts/patch/starship-sheet.mjs
+++ b/scripts/patch/starship-sheet.mjs
@@ -16,7 +16,7 @@ const STARSHIP_PACKS = new Set([
 
 const STARSHIP_TAB_ID = "sw5e-starship";
 const STARSHIP_FEATURES_TAB_ID = "sw5e-starship-features";
-const STOCK_CARGO_TAB_ID = "cargo";
+const STOCK_CARGO_TAB_ID = "inventory";
 const CUSTOM_STARSHIP_TAB_IDS = new Set([STARSHIP_TAB_ID, STARSHIP_FEATURES_TAB_ID]);
 
 function getHtmlRoot(html) {
@@ -368,13 +368,13 @@ function makeItemEntry(item, defaultTab = STOCK_CARGO_TAB_ID, actor = null) {
 
 function categorizeStarshipItems(actor) {
 	const groups = {
-		size: { label: localizeOrFallback("TYPES.Item.starshipsizePl", "Starship Size"), items: [], defaultTab: STOCK_CARGO_TAB_ID, manageLabel: "Cargo" },
-		actions: { label: localizeOrFallback("SW5E.Feature.StarshipAction.Label", "Starship Actions"), items: [], defaultTab: STOCK_CARGO_TAB_ID, manageLabel: "Cargo" },
-		roles: { label: localizeOrFallback("SW5E.Feature.Deployment.Label", "Crew Roles"), items: [], defaultTab: STOCK_CARGO_TAB_ID, manageLabel: "Cargo" },
-		features: { label: localizeOrFallback("SW5E.Feature.Starship.Label", "Starship Features"), items: [], defaultTab: STOCK_CARGO_TAB_ID, manageLabel: "Cargo" },
-		equipment: { label: localizeOrFallback("SW5E.Equipment", "Equipment"), items: [], defaultTab: STOCK_CARGO_TAB_ID, manageLabel: "Cargo" },
-		modifications: { label: localizeOrFallback("TYPES.Item.starshipmodPl", "Modifications"), items: [], defaultTab: STOCK_CARGO_TAB_ID, manageLabel: "Cargo" },
-		weapons: { label: localizeOrFallback("SW5E.Weapon", "Weapons"), items: [], defaultTab: STOCK_CARGO_TAB_ID, manageLabel: "Cargo" }
+		size: { label: localizeOrFallback("TYPES.Item.starshipsizePl", "Starship Size"), items: [], defaultTab: STOCK_CARGO_TAB_ID, manageLabel: "Cargo", scrollTo: "inventory" },
+		actions: { label: localizeOrFallback("SW5E.Feature.StarshipAction.Label", "Starship Actions"), items: [], defaultTab: null, manageLabel: "Features", scrollTo: "stations" },
+		roles: { label: localizeOrFallback("SW5E.Feature.Deployment.Label", "Crew Roles"), items: [], defaultTab: STOCK_CARGO_TAB_ID, manageLabel: "Cargo", scrollTo: "inventory" },
+		features: { label: localizeOrFallback("SW5E.Feature.Starship.Label", "Starship Features"), items: [], defaultTab: null, manageLabel: "Features", scrollTo: "stations" },
+		equipment: { label: localizeOrFallback("SW5E.Equipment", "Equipment"), items: [], defaultTab: STOCK_CARGO_TAB_ID, manageLabel: "Cargo", scrollTo: "inventory" },
+		modifications: { label: localizeOrFallback("TYPES.Item.starshipmodPl", "Modifications"), items: [], defaultTab: STOCK_CARGO_TAB_ID, manageLabel: "Cargo", scrollTo: "inventory" },
+		weapons: { label: localizeOrFallback("SW5E.Weapon", "Weapons"), items: [], defaultTab: STOCK_CARGO_TAB_ID, manageLabel: "Cargo", scrollTo: "inventory" }
 	};
 
 	for ( const item of actor.items ) {
@@ -400,6 +400,8 @@ function buildGroupContext(group) {
 		count: group.items.length,
 		defaultTab: group.defaultTab,
 		manageLabel: group.manageLabel,
+		scrollTo: group.scrollTo,
+		firstItemId: group.items[0]?.id ?? null,
 		items: group.items.sort((left, right) => left.name.localeCompare(right.name)).map(item => makeItemEntry(item, group.defaultTab, group.actor))
 	};
 }
@@ -495,7 +497,8 @@ function focusSheetItem(root, app, itemId, tabId = STOCK_CARGO_TAB_ID) {
 		// Only switch tabs if the item is inside a named tab panel; non-tab sections (e.g. stations sidebar) are always visible.
 		const panel = target.closest(".tab[data-group='primary']");
 		if ( panel?.dataset.tab ) activateSheetTab(root, app, panel.dataset.tab);
-		target.scrollIntoView({ behavior: "smooth", block: "center" });
+		// Defer scroll to next frame so the tab panel is visible (display:none → display:block) before scrollIntoView runs.
+		window.requestAnimationFrame(() => target.scrollIntoView({ behavior: "smooth", block: "center" }));
 		target.classList.add("sw5e-starship-item-pulse");
 		window.setTimeout(() => target.classList.remove("sw5e-starship-item-pulse"), 1800);
 	}, 50);
@@ -607,14 +610,14 @@ async function renderStarshipLayer(app, html, data) {
 			subtitle: localizeOrFallback("TYPES.Actor.vehicle", "Vehicle Actor"),
 			headerBadges: makeHeaderBadges(actor),
 			overviewCards: makeOverviewCards(actor),
-			groups: workspaceGroups.map(group => ({ ...group, supportsSheetNavigation: integrated })),
+			groups: workspaceGroups.map(group => ({ ...group, supportsSheetNavigation: integrated, showManageButton: integrated })),
 			legacyNotes: getLegacyNotes(actor),
 			skills
 		}),
 		foundry.applications.handlebars.renderTemplate(getModulePath("templates/starship-features-layer.hbs"), {
 			title: localizeOrFallback("SW5E.Feature.Starship.Label", "Starship Features"),
 			subtitle: "Manage configuration items and remove or replace them through the stock vehicle sheet.",
-			groups: featureGroups.map(group => ({ ...group, supportsSheetNavigation: integrated }))
+			groups: featureGroups.map(group => ({ ...group, supportsSheetNavigation: integrated, showManageButton: integrated }))
 		})
 	]);
 
@@ -688,7 +691,8 @@ async function renderStarshipLayer(app, html, data) {
 		}
 
 		if ( action === "open-tab" ) {
-			activateSheetTab(root, app, actionNode.dataset.tab);
+			const firstItemId = actionNode.dataset.firstItemId;
+			if ( firstItemId ) focusSheetItem(root, app, firstItemId);
 			return;
 		}
 

--- a/scripts/patch/starship-sheet.mjs
+++ b/scripts/patch/starship-sheet.mjs
@@ -241,8 +241,9 @@ function getDeploymentCounts(legacySystem) {
 	const deployment = legacySystem.attributes?.deployment ?? {};
 	const crew = Array.isArray(deployment.crew?.items) ? deployment.crew.items : Array.isArray(deployment.crew) ? deployment.crew : [];
 	const passenger = Array.isArray(deployment.passenger?.items) ? deployment.passenger.items : Array.isArray(deployment.passenger) ? deployment.passenger : [];
+	const rawPilot = deployment.pilot?.value ?? deployment.pilot ?? "";
 	return {
-		pilot: deployment.pilot?.value ?? deployment.pilot ?? "",
+		pilot: typeof rawPilot === "string" ? rawPilot : "",
 		crew: crew.length,
 		passenger: passenger.length
 	};

--- a/templates/starship-features-layer.hbs
+++ b/templates/starship-features-layer.hbs
@@ -17,12 +17,12 @@
           </div>
           <div class="sw5e-starship-group-tools">
             <span class="sw5e-starship-group-count">{{count}}</span>
-            {{#if supportsSheetNavigation}}
+            {{#if showManageButton}}
               <button
                 type="button"
                 class="sw5e-starship-group-link"
                 data-sw5e-action="open-tab"
-                data-tab="{{defaultTab}}"
+                data-first-item-id="{{firstItemId}}"
               >
                 Manage in {{manageLabel}}
               </button>

--- a/templates/starship-features-layer.hbs
+++ b/templates/starship-features-layer.hbs
@@ -17,7 +17,7 @@
           </div>
           <div class="sw5e-starship-group-tools">
             <span class="sw5e-starship-group-count">{{count}}</span>
-            {{#if showManageButton}}
+            {{#if supportsSheetNavigation}}
               <button
                 type="button"
                 class="sw5e-starship-group-link"

--- a/templates/starship-sheet-layer.hbs
+++ b/templates/starship-sheet-layer.hbs
@@ -85,12 +85,12 @@
           </div>
           <div class="sw5e-starship-group-tools">
             <span class="sw5e-starship-group-count">{{count}}</span>
-            {{#if supportsSheetNavigation}}
+            {{#if showManageButton}}
               <button
                 type="button"
                 class="sw5e-starship-group-link"
                 data-sw5e-action="open-tab"
-                data-tab="{{defaultTab}}"
+                data-first-item-id="{{firstItemId}}"
               >
                 Manage in {{manageLabel}}
               </button>

--- a/templates/starship-sheet-layer.hbs
+++ b/templates/starship-sheet-layer.hbs
@@ -85,7 +85,7 @@
           </div>
           <div class="sw5e-starship-group-tools">
             <span class="sw5e-starship-group-count">{{count}}</span>
-            {{#if showManageButton}}
+            {{#if supportsSheetNavigation}}
               <button
                 type="button"
                 class="sw5e-starship-group-link"


### PR DESCRIPTION
## Summary

- **Fix blank sheet on tab navigation** — `STOCK_CARGO_TAB_ID` was `"cargo"` but the actual dnd5e tab ID is `"inventory"`; passing the wrong ID caused `changeTab` to throw, falling through to `activatePrimaryTab("cargo")` which deactivated all panels. Also replaced synthetic click dispatch with `app.changeTab(..., { force: true })` so tab switches work even when `tabGroups` already matches the target.
- **Fix "Find in Sheet" for stations items blanking the features tab** — `focusSheetItem` now determines the target tab from the DOM (`.tab[data-group='primary']`). Items in the `stations` sidebar (feat-type: starship actions, features, deployments) are always visible and require no tab switch — only items in the `inventory` tab trigger a switch. `scrollIntoView` is deferred via `requestAnimationFrame` to avoid scrolling a still-hidden panel.
- **Fix "Manage in X" group buttons** — group buttons now call `focusSheetItem` on the group's first item rather than a hardcoded tab ID, so both the tab switch and scroll are handled by the same code path as per-item "Find in Sheet". Starship Actions and Starship Features show "Manage in Features" and scroll to the stations sidebar; cargo groups show "Manage in Cargo" and scroll to their section in the inventory tab.
- **Fix `Pilot: [object Object]` in crew card** — `getDeploymentCounts` now coerces the pilot value to a string, guarding against object-shaped legacy deployment data.
- **Fix raw i18n keys in equipment item meta** — `getItemMeta` now calls `game.i18n.localize()` on the subtype. Added missing keys `SW5E.EquipmentHyperdrive`, `SW5E.EquipmentPowerCoupling`, and `SW5E.EquipmentReactor` to `en.json`.
- **Fix starship actors displaying as "Air Vehicle"** — set `system.details.type = "space"` in all six starship compendium templates so newly imported actors are correctly labeled "Space Vehicle".
- **Add `docs/actor-sheet-tabs.md`** — documents the Foundry v13 tab system, dnd5e VehicleActorSheet structure, SW5E custom tab injection, item categorization (which types go to `stations` vs `inventory`), navigation rules, and common pitfalls.

## Test plan

- [ ] Open a Drake's Shipyard starship actor sheet
- [ ] SW5E tab: click "Find in Sheet" on a starship action — should scroll to stations sidebar, no tab switch
- [ ] SW5E tab: click "Manage in Features" on Starship Actions group — should scroll to stations sidebar
- [ ] SW5E tab: click "Find in Sheet" on a weapon/equipment/modification — should switch to Cargo tab and scroll to item
- [ ] SW5E tab: click "Manage in Cargo" on weapons/equipment group — should switch to Cargo tab and scroll to section
- [ ] Starship Features tab: same navigation checks for feature items
- [ ] Crew card on SW5E tab shows pilot name (not `[object Object]`) when a pilot is assigned
- [ ] Equipment items (reactors, hyperdrives, power couplings) show human-readable subtype in item sheet subtitle
- [ ] Newly imported ship from Drake's Shipyard compendium shows "Space Vehicle" in the stock sheet header

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added three new equipment item types: Hyperdrive, Power Coupling, and Reactor.
  * Enhanced starship sheet navigation with improved tab switching and item management.

* **Bug Fixes**
  * Fixed starship sheet cargo tab identification and behavior.
  * Improved localization of item subtype labels in displays.
  * Fixed pilot information parsing in deployment calculations.

* **Documentation**
  * Added comprehensive guide for actor sheet tabs and application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->