### PR TITLE
V1.3.3 pre release fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,19 @@ For the current beta coverage checklist spanning `1.2.9` and `1.3.0`, see [1.2.9
 
 ## Changelog
 
+### [1.3.4] TEMP - 2026-04-26
+
+### Added
+- Added hue-rotate filters to the dual_color_saber background image used on encounter, group, npc, vehicle and item sheets to provide a visual distinction between the sheets.
+
+### Changed
+- Removed ".dnd5e2.sheet.actor .window-content {position: relative;}" as it was causing the tabs on the group sheet to not function and was offsetting buttons on the sheet.
+
+### Fixed
+- dual_color_saber background image now replaces the DND5e image used for encounter, group, npc, vehicle and item sheets properly where it had not before due to formatting differences between the player sheet and the others.
+- Tabs of the group sheet now render properly to the right of the sheet and function as intended.
+
+
 ### [1.3.3] - 2026-04-23
 
 ### Added

--- a/styles/module.css
+++ b/styles/module.css
@@ -30,7 +30,7 @@ mask-image: linear-gradient(to bottom, black, transparent);
 content: "";
 background: url("/modules/sw5e-module/styles/dual_color_saber3.jpeg") no-repeat top center / cover;
 opacity: 0.5;
-filter: hue-rotate(90deg);
+filter: hue-rotate(315deg);
 }
 
 .dnd5e2.sheet.actor.group:not(.minimized)::before {
@@ -59,40 +59,6 @@ content: "";
 background: url("/modules/sw5e-module/styles/dual_color_saber3.jpeg") no-repeat top center / cover;
 opacity: 0.5;
 filter: hue-rotate(225deg);
-}
-
-/* Force Point CSS for the main sheet */
-
-.dnd5e2.sheet.actor .meter.sw5e-power-points .progress {
-  flex: 1 1 auto;
-  width: 100%;
-  min-width: 0;
-  position: relative;
-}
-
-.dnd5e2.sheet.actor .meter.sw5e-power-points .progress::before {
-  z-index: 0;
-}
-
-.dnd5e2.sheet.actor .meter.sw5e-power-points .progress > .label,
-.dnd5e2.sheet.actor .meter.sw5e-power-points .progress > input {
-  position: relative;
-  z-index: 1;
-}
-
-.dnd5e2.sheet.actor .meter.sw5e-power-points .progress.editing > input {
-  width: 100%;
-  height: 100%;
-  padding: 0 0.5rem;
-  text-align: center;
-  color: var(--dnd5e-color-text-dark-primary);
-  background: transparent;
-  border: 0;
-  box-shadow: none;
-}
-
-.dnd5e2.sheet.actor .meter.force-points .progress::before {
-  background: linear-gradient(to right, #08568a 0%, #AFC6D5 100%);
 }
 
 /* Force Point CSS for the main sheet */

--- a/styles/module.css
+++ b/styles/module.css
@@ -11,21 +11,88 @@
   text-align: left;
 }
 
-.dnd5e2.sheet.actor .window-content {
+/* Background of sheets */
+
+.dnd5e2.sheet.actor.character:not(.minimized) .window-content::before {
+content: "";
+position: absolute;
+inset: 0 0 auto 0;
+height: 300px;
+border-radius: inherit;
+opacity: 0.5;
+pointer-events: none;
+background: url("/modules/sw5e-module/styles/dual_color_saber3.jpeg") no-repeat top center / cover;
+-webkit-mask-image: linear-gradient(to bottom, black, transparent);
+mask-image: linear-gradient(to bottom, black, transparent);
+}
+
+.dnd5e2.sheet.actor.encounter:not(.minimized)::before {
+content: "";
+background: url("/modules/sw5e-module/styles/dual_color_saber3.jpeg") no-repeat top center / cover;
+opacity: 0.5;
+filter: hue-rotate(90deg);
+}
+
+.dnd5e2.sheet.actor.group:not(.minimized)::before {
+content: "";
+background: url("/modules/sw5e-module/styles/dual_color_saber3.jpeg") no-repeat top center / cover;
+opacity: 0.5;
+filter: hue-rotate(45deg);
+}
+
+.dnd5e2.sheet.actor.npc:not(.minimized)::before {
+content: "";
+background: url("/modules/sw5e-module/styles/dual_color_saber3.jpeg") no-repeat top center / cover;
+opacity: 0.5;
+filter: hue-rotate(135deg);
+}
+
+.dnd5e2.sheet.actor.vehicle:not(.minimized)::before {
+content: "";
+background: url("/modules/sw5e-module/styles/dual_color_saber3.jpeg") no-repeat top center / cover;
+opacity: 0.5;
+filter: hue-rotate(270deg);
+}
+
+.dnd5e2.sheet.item:not(.minimized)::before {
+content: "";
+background: url("/modules/sw5e-module/styles/dual_color_saber3.jpeg") no-repeat top center / cover;
+opacity: 0.5;
+filter: hue-rotate(225deg);
+}
+
+/* Force Point CSS for the main sheet */
+
+.dnd5e2.sheet.actor .meter.sw5e-power-points .progress {
+  flex: 1 1 auto;
+  width: 100%;
+  min-width: 0;
   position: relative;
 }
 
-.dnd5e2.sheet.actor .window-content::before {
-  content: "";
-  position: absolute;
-  inset: 0 0 auto 0;
-  height: 300px;
-  border-radius: inherit;
-  opacity: 0.5;
-  pointer-events: none;
-  background: url("/modules/sw5e-module/styles/dual_color_saber3.jpeg") no-repeat top center / cover;
-  -webkit-mask-image: linear-gradient(to bottom, black, transparent);
-  mask-image: linear-gradient(to bottom, black, transparent);
+.dnd5e2.sheet.actor .meter.sw5e-power-points .progress::before {
+  z-index: 0;
+}
+
+.dnd5e2.sheet.actor .meter.sw5e-power-points .progress > .label,
+.dnd5e2.sheet.actor .meter.sw5e-power-points .progress > input {
+  position: relative;
+  z-index: 1;
+}
+
+.dnd5e2.sheet.actor .meter.sw5e-power-points .progress.editing > input {
+  width: 100%;
+  height: 100%;
+  padding: 0 0.5rem;
+  text-align: center;
+  color: var(--dnd5e-color-text-dark-primary);
+  background: transparent;
+  border: 0;
+  box-shadow: none;
+}
+
+.dnd5e2.sheet.actor .meter.force-points .progress::before {
+  background: linear-gradient(to right, #08568a 0%, #AFC6D5 100%);
 }
 
 /* Force Point CSS for the main sheet */


### PR DESCRIPTION
Noticed that the lightsaber background on sheets did not go all the way to the top on all but the player sheet. This was because the player sheet has a mild formatting difference from the rest of them, so I added more explicit CSS for each. I also noticed that the tabs of the groups page were not working as expected and buttons on the page had strange offsets which was caused by some relative position CSS.  Finally added a small color shift to the sheet background to give some visual distinction between the sheets.

As in the README changelog:
### Added
- Added hue-rotate filters to the dual_color_saber background image used on encounter, group, npc, vehicle and item sheets to provide a visual distinction between the sheets.

### Changed
- Removed ".dnd5e2.sheet.actor .window-content {position: relative;}" as it was causing the tabs on the group sheet to not function and was offsetting buttons on the sheet.

### Fixed
- dual_color_saber background image now replaces the DND5e image used for encounter, group, npc, vehicle and item sheets properly where it had not before due to formatting differences between the player sheet and the others.
- Tabs of the group sheet now render properly to the right of the sheet and function as intended.