### PR TITLE
Fixed error preventing starship tiers from being altered.

### DIFF
--- a/languages/en.json
+++ b/languages/en.json
@@ -947,6 +947,7 @@
 	"SW5E.StarshipSheet.SystemsPlaceholderLede": "Use Operations for power routing during play. Supporting fields cover fuel and derived speeds. Classification groups list size and passive starship features—use sheet Edit mode to manage items; hull, shields, tier, and size stay in the sidebar.",
 	"SW5E.StarshipSheet.SystemsLivePlayBadge": "Usable in Play mode",
 	"SW5E.StarshipSheet.SystemsSupportingSetupHint": "Fuel and related fields are maintenance/setup — switch the sheet to Edit mode to change them.",
+	"SW5E.StarshipSheet.TierExceededWarning": "Starship Tiers cap at 5",
 	"SW5E.ModSlots": "Mod Slots",
 	"SW5E.PowerDice": "Power Dice",
 	"SW5E.PowerRouting": "Power Routing",

--- a/scripts/patch/starship-sheet.mjs
+++ b/scripts/patch/starship-sheet.mjs
@@ -774,6 +774,24 @@ async function persistStarshipFuelPowerSystemPath(act, systemPath, value) {
 	await act.update(payload);
 }
 
+/** @returns {Promise<void>} */
+async function persistStarshipTierSystemPath(act, systemPath, value) {
+	// Tier must be mirrored independently as it's not a native value in the dnd5e vehicle dataModel
+	let payload;
+    if ( systemPath === "system.details.tier" && isSw5eStarshipActor(act) ) {
+		// Tier value should cap at 5 as per SW5e ruleset
+		if( value > 5){
+			ui.notifications.warn(localizeOrFallback("SW5E.StarshipSheet.TierExceededWarning", "Starship Tiers cap at 5."));
+			value = 5;
+		}
+        payload = {
+            [systemPath]: value,
+            "flags.sw5e.legacyStarshipActor.system.details.tier": value
+        };
+    }
+	await act.update(payload);
+}
+
 function coerceSidebarTier(actor, raw) {
 	const prev = Number(actor?.system?.details?.tier);
 	const fallback = Number.isFinite(prev) ? Math.max(0, Math.trunc(prev)) : 0;
@@ -854,7 +872,11 @@ function ensureStarshipTrustedSystemPathDelegate(root, app) {
 
 			try {
 				stashStarshipPendingSidebarScroll(app, el);
-				await persistStarshipFuelPowerSystemPath(act, path, value);
+				if(path === "system.details.tier"){
+					await persistStarshipTierSystemPath(act, path, value);
+				} else {
+					await persistStarshipFuelPowerSystemPath(act, path, value);
+				}
 			} catch ( err ) {
 				consumeStarshipPendingSidebarScroll(app);
 				console.error("SW5E MODULE | Starship sidebar quick-edit update failed.", err);


### PR DESCRIPTION
The issue is that the base vehicle data model does not contain the "tier" item and as such is not inherently mirrored when a change occurs, resulting in the value being reset.

Rather than patching it into the persistStarshipFuelPowerSystemPath function, I have created a new function called persistStarshipTierSystemPath which specifically handles the Tier updating.

I have also capped the Tier value at 5 - the highest value according to the SW5e handbooks - as it was uncapped previously.

Ideally a later change would better handle the tier implementation and allow it to function as a "class" with advancements.